### PR TITLE
🌿 [do not merge] example of what `RequestOptions` will look like

### DIFF
--- a/src/main/java/com/merge/api/core/ClientOptions.java
+++ b/src/main/java/com/merge/api/core/ClientOptions.java
@@ -38,6 +38,17 @@ public final class ClientOptions {
         return values;
     }
 
+    public Map<String, String> headers(RequestOptions requestOptions) {
+        Map<String, String> values = new HashMap<>(this.headers);
+        headerSuppliers.forEach((key, supplier) -> {
+            values.put(key, supplier.get());
+        });
+        if (requestOptions != null) {
+            values.putAll(requestOptions.getHeaders());
+        }
+        return values;
+    }
+
     public OkHttpClient httpClient() {
         return this.httpClient;
     }

--- a/src/main/java/com/merge/api/core/RequestOptions.java
+++ b/src/main/java/com/merge/api/core/RequestOptions.java
@@ -1,0 +1,50 @@
+package com.merge.api.core;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public final class RequestOptions {
+
+    public final String apiKey;
+    public final String accountToken;
+
+    private RequestOptions(String apiKey, String accountToken) {
+        this.apiKey = apiKey;
+        this.accountToken = accountToken;
+    }
+
+    public Map<String, String> getHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        if (this.apiKey != null) {
+            headers.put("Authorization", "Bearer " + this.apiKey);
+        }
+        if (this.apiKey != null) {
+            headers.put("X-Account-Token", this.accountToken);
+        }
+        return headers;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private String apiKey = null;
+
+        private String accountToken = null;
+
+        public Builder apiKey(String apiKey) {
+            return this;
+        }
+
+        public Builder accountToken(String accountToken) {
+            return this;
+        }
+
+        public RequestOptions build() {
+            return new RequestOptions(apiKey, accountToken);
+        }
+    }
+}

--- a/src/main/java/com/merge/api/resources/hris/employees/EmployeesClient.java
+++ b/src/main/java/com/merge/api/resources/hris/employees/EmployeesClient.java
@@ -2,6 +2,7 @@ package com.merge.api.resources.hris.employees;
 
 import com.merge.api.core.ClientOptions;
 import com.merge.api.core.ObjectMappers;
+import com.merge.api.core.RequestOptions;
 import com.merge.api.resources.hris.employees.requests.EmployeeEndpointRequest;
 import com.merge.api.resources.hris.employees.requests.EmployeesListRequest;
 import com.merge.api.resources.hris.employees.requests.EmployeesRetrieveRequest;
@@ -27,6 +28,10 @@ public class EmployeesClient {
     }
 
     public PaginatedEmployeeList list(EmployeesListRequest request) {
+        return list(request, null);
+    }
+
+    public PaginatedEmployeeList list(EmployeesListRequest request, RequestOptions requestOptions) {
         HttpUrl.Builder _httpUrl = HttpUrl.parse(
                         this.clientOptions.environment().getUrl())
                 .newBuilder()
@@ -141,7 +146,7 @@ public class EmployeesClient {
         Request.Builder _requestBuilder = new Request.Builder()
                 .url(_httpUrl.build())
                 .method("GET", _requestBody)
-                .headers(Headers.of(clientOptions.headers()))
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
                 .addHeader("Content-Type", "application/json");
         Request _request = _requestBuilder.build();
         try {


### PR DESCRIPTION
Fern will overload all endpoint methods with a method that contains a `RequestOptions` parameter. If the request options contains overridden headers such as a different api key or different account token, then those will be used instead. 

Overtime more request specific parameters such as timeout, generic query params, can be added here. 