### PR TITLE
Handle errors with null response bodies

### DIFF
--- a/src/main/java/com/merge/api/resources/ticketing/tickets/TicketsClient.java
+++ b/src/main/java/com/merge/api/resources/ticketing/tickets/TicketsClient.java
@@ -237,7 +237,11 @@ public class TicketsClient {
             }
             throw new ApiError(
                     response.code(),
-                    ObjectMappers.JSON_MAPPER.readValue(response.body().string(), Object.class));
+                    ObjectMappers.JSON_MAPPER.readValue(
+                            response.body() != null
+                                    ? response.body().toString()
+                                    : "{}",
+                            Object.class));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Currently we're seeing errors like this:

```
com.merge.api.core.ApiError: null
	at com.merge.api.resources.ticketing.tickets.TicketsClient.create(TicketsClient.java:240)
```

My guess is that `response.body()` is null on some error, so this change puts a safeguard in place to avoid the NPE.