### PR TITLE
Remove `ApiError.java` from `.fernignore`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -3,4 +3,3 @@
 README.md
 LICENSE.md
 
-src/main/java/com/merge/api/core/ApiError.java


### PR DESCRIPTION
This PR removes `ApiError.java` from `.fernignore`, as we can now generate `ApiError.java` directly in the generator.