### PR TITLE
Adding POC for a client options configurer.

### DIFF
--- a/src/main/java/com/merge/api/MergeApiClientBuilder.java
+++ b/src/main/java/com/merge/api/MergeApiClientBuilder.java
@@ -5,6 +5,9 @@ package com.merge.api;
 
 import com.merge.api.core.ClientOptions;
 import com.merge.api.core.Environment;
+import okhttp3.OkHttpClient;
+
+import java.util.function.Consumer;
 
 public final class MergeApiClientBuilder {
     private ClientOptions.Builder clientOptionsBuilder = ClientOptions.builder();
@@ -14,6 +17,8 @@ public final class MergeApiClientBuilder {
     private String accountToken = null;
 
     private Environment environment = Environment.PRODUCTION;
+
+    private Consumer<OkHttpClient.Builder> okHttpConfigurer;
 
     /**
      * Sets apiKey
@@ -41,6 +46,11 @@ public final class MergeApiClientBuilder {
         return this;
     }
 
+    public MergeApiClientBuilder okHttpConfigurer(Consumer<OkHttpClient.Builder> okHttpConfigurer) {
+        this.okHttpConfigurer = okHttpConfigurer;
+        return this;
+    }
+
     public MergeApiClient build() {
         if (apiKey == null) {
             throw new RuntimeException("Please provide apiKey");
@@ -50,6 +60,9 @@ public final class MergeApiClientBuilder {
             this.clientOptionsBuilder.addHeader("X-Account-Token", this.accountToken);
         }
         clientOptionsBuilder.environment(this.environment);
+        if (okHttpConfigurer != null) {
+            clientOptionsBuilder.addOkHttpConfigurer(okHttpConfigurer);
+        }
         return new MergeApiClient(clientOptionsBuilder.build());
     }
 }


### PR DESCRIPTION
We've been facing an error with a passthrough request where the response headers are too big for the HTTP client.

Can we add a means to allow configuring the underlying HTTP client, just so that we can supply a few tweaks to make it work for this request?