### PR TITLE
update maven central url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          MAVEN_PUBLISH_REGISTRY_URL: "https://s01.oss.sonatype.org/content/repositories/releases/"
+          MAVEN_PUBLISH_REGISTRY_URL: "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        url 'https://s01.oss.sonatype.org/content/repositories/releases/'
+        url 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
     }
 }
 


### PR DESCRIPTION
https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#getting-started-for-maven-api-like-plugins

Based on maven documentation for gradle the url should be `https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/`