### PR TITLE
Format hand-maintained tests with Spotless + add CI formatting gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Compile
         run: ./gradlew compileJava
 
+      - name: Check formatting
+        run: ./gradlew spotlessCheck
+
   test:
     needs: [ compile ]
     runs-on: ubuntu-latest

--- a/src/test/java/com/merge/api/custom/DateTimeSerializationTest.java
+++ b/src/test/java/com/merge/api/custom/DateTimeSerializationTest.java
@@ -11,8 +11,8 @@ public final class DateTimeSerializationTest {
 
     @Test
     public void utcDatetimeSerializesWithZuluOffset() throws Exception {
-        Employee employee = ObjectMappers.JSON_MAPPER.readValue(
-                "{\"modified_at\":\"2026-01-15T09:30:00Z\"}", Employee.class);
+        Employee employee =
+                ObjectMappers.JSON_MAPPER.readValue("{\"modified_at\":\"2026-01-15T09:30:00Z\"}", Employee.class);
 
         assertTrue(employee.getModifiedAt().isPresent());
         String serialized = ObjectMappers.JSON_MAPPER.writeValueAsString(employee);
@@ -21,12 +21,10 @@ public final class DateTimeSerializationTest {
 
     @Test
     public void datetimeRoundTripPreservesInstant() throws Exception {
-        Employee employee = ObjectMappers.JSON_MAPPER.readValue(
-                "{\"modified_at\":\"2026-01-15T09:30:00-05:00\"}", Employee.class);
+        Employee employee =
+                ObjectMappers.JSON_MAPPER.readValue("{\"modified_at\":\"2026-01-15T09:30:00-05:00\"}", Employee.class);
 
         OffsetDateTime modifiedAt = employee.getModifiedAt().get();
-        assertEquals(
-                OffsetDateTime.parse("2026-01-15T09:30:00-05:00").toInstant(),
-                modifiedAt.toInstant());
+        assertEquals(OffsetDateTime.parse("2026-01-15T09:30:00-05:00").toInstant(), modifiedAt.toInstant());
     }
 }

--- a/src/test/java/com/merge/api/custom/EnvironmentRoutingTest.java
+++ b/src/test/java/com/merge/api/custom/EnvironmentRoutingTest.java
@@ -24,6 +24,8 @@ public final class EnvironmentRoutingTest {
 
     @Test
     public void customUrlRoundTrips() {
-        assertEquals("http://localhost:8080", Environment.custom("http://localhost:8080").getUrl());
+        assertEquals(
+                "http://localhost:8080",
+                Environment.custom("http://localhost:8080").getUrl());
     }
 }

--- a/src/test/java/com/merge/api/custom/ExpandQueryParamTest.java
+++ b/src/test/java/com/merge/api/custom/ExpandQueryParamTest.java
@@ -6,7 +6,6 @@ import com.merge.api.core.QueryStringMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import okhttp3.HttpUrl;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/merge/api/integration/AtsIntegrationTest.java
+++ b/src/test/java/com/merge/api/integration/AtsIntegrationTest.java
@@ -39,42 +39,49 @@ public class AtsIntegrationTest {
     @Test
     void activities() {
         smokeListAndRetrieve(
-                client.ats().activities().list(), id -> client.ats().activities().retrieve(id));
+                client.ats().activities().list(),
+                id -> client.ats().activities().retrieve(id));
     }
 
     @Test
     void applications() {
         smokeListAndRetrieve(
-                client.ats().applications().list(), id -> client.ats().applications().retrieve(id));
+                client.ats().applications().list(),
+                id -> client.ats().applications().retrieve(id));
     }
 
     @Test
     void attachments() {
         smokeListAndRetrieve(
-                client.ats().attachments().list(), id -> client.ats().attachments().retrieve(id));
+                client.ats().attachments().list(),
+                id -> client.ats().attachments().retrieve(id));
     }
 
     @Test
     void candidates() {
         smokeListAndRetrieve(
-                client.ats().candidates().list(), id -> client.ats().candidates().retrieve(id));
+                client.ats().candidates().list(),
+                id -> client.ats().candidates().retrieve(id));
     }
 
     @Test
     void departments() {
         smokeListAndRetrieve(
-                client.ats().departments().list(), id -> client.ats().departments().retrieve(id));
+                client.ats().departments().list(),
+                id -> client.ats().departments().retrieve(id));
     }
 
     @Test
     void eeocs() {
-        smokeListAndRetrieve(client.ats().eeocs().list(), id -> client.ats().eeocs().retrieve(id));
+        smokeListAndRetrieve(
+                client.ats().eeocs().list(), id -> client.ats().eeocs().retrieve(id));
     }
 
     @Test
     void interviews() {
         smokeListAndRetrieve(
-                client.ats().interviews().list(), id -> client.ats().interviews().retrieve(id));
+                client.ats().interviews().list(),
+                id -> client.ats().interviews().retrieve(id));
     }
 
     @Test
@@ -87,39 +94,46 @@ public class AtsIntegrationTest {
     @Test
     void jobPostings() {
         smokeListAndRetrieve(
-                client.ats().jobPostings().list(), id -> client.ats().jobPostings().retrieve(id));
+                client.ats().jobPostings().list(),
+                id -> client.ats().jobPostings().retrieve(id));
     }
 
     @Test
     void jobs() {
-        smokeListAndRetrieve(client.ats().jobs().list(), id -> client.ats().jobs().retrieve(id));
+        smokeListAndRetrieve(
+                client.ats().jobs().list(), id -> client.ats().jobs().retrieve(id));
     }
 
     @Test
     void offers() {
-        smokeListAndRetrieve(client.ats().offers().list(), id -> client.ats().offers().retrieve(id));
+        smokeListAndRetrieve(
+                client.ats().offers().list(), id -> client.ats().offers().retrieve(id));
     }
 
     @Test
     void offices() {
-        smokeListAndRetrieve(client.ats().offices().list(), id -> client.ats().offices().retrieve(id));
+        smokeListAndRetrieve(
+                client.ats().offices().list(), id -> client.ats().offices().retrieve(id));
     }
 
     @Test
     void rejectReasons() {
         smokeListAndRetrieve(
-                client.ats().rejectReasons().list(), id -> client.ats().rejectReasons().retrieve(id));
+                client.ats().rejectReasons().list(),
+                id -> client.ats().rejectReasons().retrieve(id));
     }
 
     @Test
     void scorecards() {
         smokeListAndRetrieve(
-                client.ats().scorecards().list(), id -> client.ats().scorecards().retrieve(id));
+                client.ats().scorecards().list(),
+                id -> client.ats().scorecards().retrieve(id));
     }
 
     @Test
     void users() {
-        smokeListAndRetrieve(client.ats().users().list(), id -> client.ats().users().retrieve(id));
+        smokeListAndRetrieve(
+                client.ats().users().list(), id -> client.ats().users().retrieve(id));
     }
 
     @Test
@@ -134,8 +148,7 @@ public class AtsIntegrationTest {
                 .list(ApplicationsListRequest.builder()
                         .pageSize(5)
                         .expand(List.of(
-                                ApplicationsListRequestExpandItem.CANDIDATE,
-                                ApplicationsListRequestExpandItem.OFFERS))
+                                ApplicationsListRequestExpandItem.CANDIDATE, ApplicationsListRequestExpandItem.OFFERS))
                         .build()));
     }
 
@@ -158,8 +171,7 @@ public class AtsIntegrationTest {
                 .list(InterviewsListRequest.builder()
                         .pageSize(5)
                         .expand(List.of(
-                                InterviewsListRequestExpandItem.APPLICATION,
-                                InterviewsListRequestExpandItem.ORGANIZER))
+                                InterviewsListRequestExpandItem.APPLICATION, InterviewsListRequestExpandItem.ORGANIZER))
                         .build()));
     }
 

--- a/src/test/java/com/merge/api/integration/CrmIntegrationTest.java
+++ b/src/test/java/com/merge/api/integration/CrmIntegrationTest.java
@@ -65,17 +65,20 @@ public class CrmIntegrationTest {
     @Test
     void engagements() {
         smokeListAndRetrieve(
-                client.crm().engagements().list(), id -> client.crm().engagements().retrieve(id));
+                client.crm().engagements().list(),
+                id -> client.crm().engagements().retrieve(id));
     }
 
     @Test
     void leads() {
-        smokeListAndRetrieve(client.crm().leads().list(), id -> client.crm().leads().retrieve(id));
+        smokeListAndRetrieve(
+                client.crm().leads().list(), id -> client.crm().leads().retrieve(id));
     }
 
     @Test
     void notes() {
-        smokeListAndRetrieve(client.crm().notes().list(), id -> client.crm().notes().retrieve(id));
+        smokeListAndRetrieve(
+                client.crm().notes().list(), id -> client.crm().notes().retrieve(id));
     }
 
     @Test
@@ -87,17 +90,20 @@ public class CrmIntegrationTest {
 
     @Test
     void stages() {
-        smokeListAndRetrieve(client.crm().stages().list(), id -> client.crm().stages().retrieve(id));
+        smokeListAndRetrieve(
+                client.crm().stages().list(), id -> client.crm().stages().retrieve(id));
     }
 
     @Test
     void tasks() {
-        smokeListAndRetrieve(client.crm().tasks().list(), id -> client.crm().tasks().retrieve(id));
+        smokeListAndRetrieve(
+                client.crm().tasks().list(), id -> client.crm().tasks().retrieve(id));
     }
 
     @Test
     void users() {
-        smokeListAndRetrieve(client.crm().users().list(), id -> client.crm().users().retrieve(id));
+        smokeListAndRetrieve(
+                client.crm().users().list(), id -> client.crm().users().retrieve(id));
     }
 
     @Test
@@ -117,8 +123,7 @@ public class CrmIntegrationTest {
                 .list(EngagementsListRequest.builder()
                         .pageSize(5)
                         .expand(List.of(
-                                EngagementsListRequestExpandItem.CONTACTS,
-                                EngagementsListRequestExpandItem.OWNER))
+                                EngagementsListRequestExpandItem.CONTACTS, EngagementsListRequestExpandItem.OWNER))
                         .build()));
     }
 
@@ -149,8 +154,7 @@ public class CrmIntegrationTest {
                 .list(OpportunitiesListRequest.builder()
                         .pageSize(5)
                         .expand(List.of(
-                                OpportunitiesListRequestExpandItem.ACCOUNT,
-                                OpportunitiesListRequestExpandItem.OWNER))
+                                OpportunitiesListRequestExpandItem.ACCOUNT, OpportunitiesListRequestExpandItem.OWNER))
                         .build()));
     }
 

--- a/src/test/java/com/merge/api/integration/FileStorageIntegrationTest.java
+++ b/src/test/java/com/merge/api/integration/FileStorageIntegrationTest.java
@@ -40,7 +40,8 @@ public class FileStorageIntegrationTest {
     @Test
     void files() {
         smokeListAndRetrieve(
-                client.fileStorage().files().list(), id -> client.fileStorage().files().retrieve(id));
+                client.fileStorage().files().list(),
+                id -> client.fileStorage().files().retrieve(id));
     }
 
     @Test
@@ -60,7 +61,8 @@ public class FileStorageIntegrationTest {
     @Test
     void users() {
         smokeListAndRetrieve(
-                client.fileStorage().users().list(), id -> client.fileStorage().users().retrieve(id));
+                client.fileStorage().users().list(),
+                id -> client.fileStorage().users().retrieve(id));
     }
 
     @Test
@@ -80,8 +82,7 @@ public class FileStorageIntegrationTest {
                 .list(FoldersListRequest.builder()
                         .pageSize(5)
                         .expand(List.of(
-                                FoldersListRequestExpandItem.PERMISSIONS,
-                                FoldersListRequestExpandItem.PARENT_FOLDER))
+                                FoldersListRequestExpandItem.PERMISSIONS, FoldersListRequestExpandItem.PARENT_FOLDER))
                         .build()));
     }
 

--- a/src/test/java/com/merge/api/integration/HrisIntegrationTest.java
+++ b/src/test/java/com/merge/api/integration/HrisIntegrationTest.java
@@ -47,13 +47,15 @@ public class HrisIntegrationTest {
     @Test
     void companies() {
         smokeListAndRetrieve(
-                client.hris().companies().list(), id -> client.hris().companies().retrieve(id));
+                client.hris().companies().list(),
+                id -> client.hris().companies().retrieve(id));
     }
 
     @Test
     void dependents() {
         smokeListAndRetrieve(
-                client.hris().dependents().list(), id -> client.hris().dependents().retrieve(id));
+                client.hris().dependents().list(),
+                id -> client.hris().dependents().retrieve(id));
     }
 
     @Test
@@ -66,7 +68,8 @@ public class HrisIntegrationTest {
     @Test
     void employees() {
         smokeListAndRetrieve(
-                client.hris().employees().list(), id -> client.hris().employees().retrieve(id));
+                client.hris().employees().list(),
+                id -> client.hris().employees().retrieve(id));
     }
 
     @Test
@@ -79,7 +82,8 @@ public class HrisIntegrationTest {
     @Test
     void employments() {
         smokeListAndRetrieve(
-                client.hris().employments().list(), id -> client.hris().employments().retrieve(id));
+                client.hris().employments().list(),
+                id -> client.hris().employments().retrieve(id));
     }
 
     @Test
@@ -91,24 +95,28 @@ public class HrisIntegrationTest {
     @Test
     void locations() {
         smokeListAndRetrieve(
-                client.hris().locations().list(), id -> client.hris().locations().retrieve(id));
+                client.hris().locations().list(),
+                id -> client.hris().locations().retrieve(id));
     }
 
     @Test
     void payGroups() {
         smokeListAndRetrieve(
-                client.hris().payGroups().list(), id -> client.hris().payGroups().retrieve(id));
+                client.hris().payGroups().list(),
+                id -> client.hris().payGroups().retrieve(id));
     }
 
     @Test
     void payrollRuns() {
         smokeListAndRetrieve(
-                client.hris().payrollRuns().list(), id -> client.hris().payrollRuns().retrieve(id));
+                client.hris().payrollRuns().list(),
+                id -> client.hris().payrollRuns().retrieve(id));
     }
 
     @Test
     void teams() {
-        smokeListAndRetrieve(client.hris().teams().list(), id -> client.hris().teams().retrieve(id));
+        smokeListAndRetrieve(
+                client.hris().teams().list(), id -> client.hris().teams().retrieve(id));
     }
 
     @Test
@@ -138,8 +146,7 @@ public class HrisIntegrationTest {
                 .list(EmployeesListRequest.builder()
                         .pageSize(5)
                         .expand(List.of(
-                                EmployeesListRequestExpandItem.EMPLOYMENTS,
-                                EmployeesListRequestExpandItem.PAY_GROUP))
+                                EmployeesListRequestExpandItem.EMPLOYMENTS, EmployeesListRequestExpandItem.PAY_GROUP))
                         .build()));
     }
 

--- a/src/test/java/com/merge/api/integration/TicketingIntegrationTest.java
+++ b/src/test/java/com/merge/api/integration/TicketingIntegrationTest.java
@@ -77,19 +77,22 @@ public class TicketingIntegrationTest {
     @Test
     void roles() {
         smokeListAndRetrieve(
-                client.ticketing().roles().list(), id -> client.ticketing().roles().retrieve(id));
+                client.ticketing().roles().list(),
+                id -> client.ticketing().roles().retrieve(id));
     }
 
     @Test
     void tags() {
         smokeListAndRetrieve(
-                client.ticketing().tags().list(), id -> client.ticketing().tags().retrieve(id));
+                client.ticketing().tags().list(),
+                id -> client.ticketing().tags().retrieve(id));
     }
 
     @Test
     void teams() {
         smokeListAndRetrieve(
-                client.ticketing().teams().list(), id -> client.ticketing().teams().retrieve(id));
+                client.ticketing().teams().list(),
+                id -> client.ticketing().teams().retrieve(id));
     }
 
     @Test
@@ -102,7 +105,8 @@ public class TicketingIntegrationTest {
     @Test
     void users() {
         smokeListAndRetrieve(
-                client.ticketing().users().list(), id -> client.ticketing().users().retrieve(id));
+                client.ticketing().users().list(),
+                id -> client.ticketing().users().retrieve(id));
     }
 
     @Test
@@ -111,8 +115,7 @@ public class TicketingIntegrationTest {
                 .tickets()
                 .list(TicketsListRequest.builder()
                         .pageSize(5)
-                        .expand(List.of(
-                                TicketsListRequestExpandItem.ASSIGNEES, TicketsListRequestExpandItem.ACCOUNT))
+                        .expand(List.of(TicketsListRequestExpandItem.ASSIGNEES, TicketsListRequestExpandItem.ACCOUNT))
                         .build()));
     }
 


### PR DESCRIPTION
## Summary

Fixes the `spotlessJavaCheck` failure that surfaced during publish, and adds a formatting gate to CI so it can't recur.

- **Apply Spotless formatting** (`spotlessApply` / palantir-java-format) to the hand-maintained `custom/` and `integration/` test classes added in the last release, and drop an unused import in `ExpandQueryParamTest`. No behavior changes.
- **Run `spotlessCheck` in CI** — added a *Check formatting* step to the `compile` job so violations fail fast on every push/PR instead of only during the publish build.

## Why

Spotless previously ran only as part of the publish/`assemble` build (on tags), so a formatting violation slipped past push/PR and failed at publish time. Since `test` and `publish` both `needs: [compile]`, running `spotlessCheck` in `compile` now fails the pipeline early.

## Verification

- `./gradlew spotlessCheck` → BUILD SUCCESSFUL
- `./gradlew compileTestJava` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)